### PR TITLE
Retry container connection forever (or until aborted) in TaskRuns

### DIFF
--- a/src/CoreLibrary/Resources/Resources.Designer.cs
+++ b/src/CoreLibrary/Resources/Resources.Designer.cs
@@ -952,6 +952,15 @@ namespace Microsoft.FactoryOrchestrator.Core {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Waiting for the container to be ready....
+        /// </summary>
+        public static string WaitingForContainerStart {
+            get {
+                return ResourceManager.GetString("WaitingForContainerStart", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to TaskRun {0} is waiting on a result run by the container..
         /// </summary>
         public static string WaitingForContainerTaskRun {

--- a/src/CoreLibrary/Resources/Resources.resx
+++ b/src/CoreLibrary/Resources/Resources.resx
@@ -452,4 +452,8 @@
   <data name="ContainerDisabledException" xml:space="preserve">
     <value>Container support is disabled!</value>
   </data>
+  <data name="WaitingForContainerStart" xml:space="preserve">
+    <value>Waiting for the container to be ready...</value>
+    <comment>Message shown when the container inside the host is not yet ready to execute the desired Task.</comment>
+  </data>
 </root>


### PR DESCRIPTION
Still seeing test failures due to timeouts. This is better imo anyway as it puts the user in charge of deciding the acceptable seconds to wait with the Task's timeout attribute.