### PR TITLE
Hide Container checkboxes in app if disabled by policy or not supported by OS; Other app UI improvements

### DIFF
--- a/src/App/AboutPage.xaml
+++ b/src/App/AboutPage.xaml
@@ -8,31 +8,38 @@
     mc:Ignorable="d"
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 
-    <Grid>
-        <Grid.RowDefinitions>
-            <RowDefinition Height="Auto"></RowDefinition>
-            <RowDefinition Height="50"></RowDefinition>
-            <RowDefinition Height="Auto"></RowDefinition>
-            <RowDefinition Height="*"></RowDefinition>
-        </Grid.RowDefinitions>
-        <Button x:Name="BackButton" Grid.Row="0" VerticalAlignment="Top" Click="Back_Click" Style="{StaticResource NavigationBackButtonNormalStyle}" Visibility="Collapsed" AutomationProperties.Name="Go Back"/>
-        <StackPanel Orientation="Vertical" Grid.Row="0" Margin="5">
-            <TextBlock Text="Factory Orchestrator" Style="{StaticResource HeaderTextBlockStyle}" HorizontalAlignment="Center"/>
-            <TextBlock x:Name="AppVersionText" Style="{StaticResource SubheaderTextBlockStyle}" HorizontalAlignment="Center"/>
-            <TextBlock x:Name="ServiceVersionText" Style="{StaticResource SubheaderTextBlockStyle}" HorizontalAlignment="Center"/>
-            <TextBlock Text="" Style="{StaticResource SubheaderTextBlockStyle}" HorizontalAlignment="Center"/>
-            <TextBlock Text="(c) Microsoft Corporation" Style="{StaticResource SubheaderTextBlockStyle}" HorizontalAlignment="Center"/>
-        </StackPanel>
-        <StackPanel Orientation="Vertical" VerticalAlignment="Bottom" Grid.Row="2" Margin="5">
-            <TextBlock x:Name="oss" x:Uid="OSSAcknowledgments" HorizontalAlignment="Center" Style="{StaticResource SubtitleTextBlockStyle}"/>
-            <TextBlock Text="IpcServiceFramework - Jacques Kang - MIT License - https://github.com/jacqueskang/IpcServiceFramework" HorizontalAlignment="Left"/>
-            <TextBlock Text="DotNetCore.WindowsService - Peter Kottas - MIT License - https://github.com/PeterKottas/DotNetCore.WindowsService" HorizontalAlignment="Left"/>
-            <TextBlock Text="WindowsDevicePortalWrapper - Microsoft Corporation and mgurlitz - MIT License - https://github.com/mgurlitz/WindowsDevicePortalWrapper/tree/feat-standard" HorizontalAlignment="Left"/>
-            <TextBlock Text="Pe-Utility - Andres Traks - MIT License - https://github.com/AndresTraks/pe-utility" HorizontalAlignment="Left"/>
-        </StackPanel>
-        <ScrollViewer x:Name="ScrollView" HorizontalScrollBarVisibility="Auto" Grid.Row="3">
-            <TextBlock Margin="0,20" x:Name="NoticeBlock" Text="" Style="{StaticResource BodyTextBlockStyle}" HorizontalAlignment="Left" />
-        </ScrollViewer>
+    <ScrollViewer IsVerticalScrollChainingEnabled="True" VerticalScrollBarVisibility="Visible">
+        <Grid>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"></RowDefinition>
+                <RowDefinition Height="Auto"></RowDefinition>
+                <RowDefinition Height="40"></RowDefinition>
+                <RowDefinition Height="Auto"></RowDefinition>
+                <RowDefinition Height="*"></RowDefinition>
+            </Grid.RowDefinitions>
+            <Button x:Name="BackButton" Grid.Row="0" VerticalAlignment="Top" Click="Back_Click" Style="{StaticResource NavigationBackButtonNormalStyle}" Visibility="Collapsed" AutomationProperties.Name="Go Back"/>
+            <StackPanel Orientation="Vertical" Grid.Row="0" Margin="5">
+                <TextBlock Text="Factory Orchestrator" Style="{StaticResource HeaderTextBlockStyle}" HorizontalAlignment="Center"/>
+                <TextBlock x:Name="AppVersionText" Style="{StaticResource SubheaderTextBlockStyle}" HorizontalAlignment="Center"/>
+                <TextBlock x:Name="ServiceVersionText" Style="{StaticResource SubheaderTextBlockStyle}" HorizontalAlignment="Center"/>
+                <TextBlock Text="" Style="{StaticResource SubheaderTextBlockStyle}" HorizontalAlignment="Center"/>
+                <TextBlock Text="(c) Microsoft Corporation" Style="{StaticResource SubheaderTextBlockStyle}" HorizontalAlignment="Center"/>
+            </StackPanel>
+            <StackPanel x:Name="ServiceInformationStack" Orientation="Vertical" Grid.Row="1" Margin="10" Visibility="Collapsed">
+                <TextBlock x:Name="ServiceInformation" x:Uid="ServiceInformation" Style="{StaticResource HeaderTextBlockStyle}" HorizontalAlignment="Center"/>
+                <TextBlock x:Name="NetworkAccess" x:Uid="NetworkAccess" HorizontalAlignment="Center"/>
+                <TextBlock x:Name="ContainerSupport" x:Uid="ContainerSupport" HorizontalAlignment="Center"/>
+                <TextBlock x:Name="ContainerRunning" x:Uid="ContainerRunning" HorizontalAlignment="Center"/>
+            </StackPanel>
+            <StackPanel Orientation="Vertical" VerticalAlignment="Bottom" Grid.Row="3" Margin="5">
+                <TextBlock x:Name="oss" x:Uid="OSSAcknowledgments" HorizontalAlignment="Center" Style="{StaticResource SubtitleTextBlockStyle}"/>
+                <TextBlock Text="IpcServiceFramework - Jacques Kang - MIT License - https://github.com/jacqueskang/IpcServiceFramework" HorizontalAlignment="Left"/>
+                <TextBlock Text="DotNetCore.WindowsService - Peter Kottas - MIT License - https://github.com/PeterKottas/DotNetCore.WindowsService" HorizontalAlignment="Left"/>
+                <TextBlock Text="WindowsDevicePortalWrapper - Microsoft Corporation and mgurlitz - MIT License - https://github.com/mgurlitz/WindowsDevicePortalWrapper/tree/feat-standard" HorizontalAlignment="Left"/>
+                <TextBlock Text="Pe-Utility - Andres Traks - MIT License - https://github.com/AndresTraks/pe-utility" HorizontalAlignment="Left"/>
+            </StackPanel>
+            <TextBlock Margin="0,20" x:Name="NoticeBlock" Text="" Style="{StaticResource BodyTextBlockStyle}" HorizontalAlignment="Left"  Grid.Row="4" />
+         </Grid>
+    </ScrollViewer>
 
-    </Grid>
 </Page>

--- a/src/App/AboutPage.xaml.cs
+++ b/src/App/AboutPage.xaml.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 using Microsoft.FactoryOrchestrator.Client;
+using Microsoft.FactoryOrchestrator.Core;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -53,14 +54,32 @@ namespace Microsoft.FactoryOrchestrator.UWP
         {
             if (Client != null)
             {
+                ServiceInformationStack.Visibility = Visibility.Visible;
+
                 try
                 {
                     ServiceVersionText.Text = $"{resourceLoader.GetString("ServiceVersion")}: ";
                     ServiceVersionText.Text += await Client.GetServiceVersionString();
+                    NetworkAccess.Text += await Client.IsNetworkAccessEnabled() ? " ✔" : " ❌";
                 }
-                catch (FactoryOrchestratorConnectionException)
+                catch (Exception)
                 {
                     // Just ignore it
+                }
+                try
+                {
+                    // Throws exception if container is missing
+                    ContainerRunning.Text += await Client.IsContainerRunning() ? " ✔" : " ❌";
+                    ContainerSupport.Text += "✔";
+                }
+                catch (FactoryOrchestratorContainerDisabledException)
+                {
+                    ContainerRunning.Visibility = Visibility.Collapsed;
+                    ContainerSupport.Text += "❌";
+                }
+                catch (Exception)
+                {
+                    ContainerRunning.Visibility = Visibility.Collapsed;
                 }
             }
 

--- a/src/App/App.xaml.cs
+++ b/src/App/App.xaml.cs
@@ -531,6 +531,10 @@ namespace Microsoft.FactoryOrchestrator.UWP
                     case ServiceEventType.ContainerDisconnected:
                         IsContainerRunning = false;
                         break;
+                    case ServiceEventType.ContainerDisabled:
+                        IsContainerRunning = false;
+                        IsContainerDisabled = true;
+                        break;
                     default:
                         // Ignore other events
                         break;
@@ -625,7 +629,24 @@ namespace Microsoft.FactoryOrchestrator.UWP
                 }
             }
         }
-        private bool _isContainerRunning;
+        /// <summary>
+        /// <c>true</c> if the connected device has container support disabled; otherwise, <c>false</c>.
+        /// </summary>
+        public bool IsContainerDisabled
+        {
+            get => _isContainerDisabled;
+            set
+            {
+                if (!Equals(value, _isContainerDisabled))
+                {
+                    _isContainerDisabled = value;
+                    PropertyChanged?.Invoke(this, new System.ComponentModel.PropertyChangedEventArgs(nameof(IsContainerDisabled)));
+                }
+            }
+        }
+
+        private bool _isContainerRunning = false;
+        private bool _isContainerDisabled = false;
 
         private readonly SemaphoreSlim connectionFailureSem;
         private readonly SemaphoreSlim pollingFailureSem;

--- a/src/App/ConsolePage.xaml.cs
+++ b/src/App/ConsolePage.xaml.cs
@@ -30,7 +30,7 @@ namespace Microsoft.FactoryOrchestrator.UWP
             _outSem = new SemaphoreSlim(1, 1);
             _activeRunSem = new SemaphoreSlim(1, 1);
             _newCmd = false;
-            ((App)Application.Current).PropertyChanged += ConsolePage_AppPropertyChanged; ;
+            ((App)Application.Current).PropertyChanged += ConsolePage_AppPropertyChanged;
         }
 
         private async void ConsolePage_AppPropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
@@ -50,6 +50,20 @@ namespace Microsoft.FactoryOrchestrator.UWP
                     }
                 });
             }
+            else if (e.PropertyName.Equals("IsContainerDisabled", StringComparison.Ordinal))
+            {
+                await Dispatcher.RunAsync(CoreDispatcherPriority.Normal, () =>
+                {
+                    if (((App)Application.Current).IsContainerDisabled)
+                    {
+                        ContainerCheckBox.Visibility = Visibility.Collapsed;
+                    }
+                    else
+                    {
+                        ContainerCheckBox.Visibility = Visibility.Visible;
+                    }
+                });
+            }
         }
 
         protected override void OnNavigatedTo(NavigationEventArgs e)
@@ -62,14 +76,22 @@ namespace Microsoft.FactoryOrchestrator.UWP
                 _taskRunPoller.StartPolling(Client);
             }
 
-            if (((App)Application.Current).IsContainerRunning)
+            if (((App)Application.Current).IsContainerDisabled)
             {
-                ContainerCheckBox.IsEnabled = true;
+                ContainerCheckBox.Visibility = Visibility.Collapsed;
             }
             else
             {
-                ContainerCheckBox.IsEnabled = false;
-                ContainerCheckBox.IsChecked = false;
+                ContainerCheckBox.Visibility = Visibility.Visible;
+                if (((App)Application.Current).IsContainerRunning)
+                {
+                    ContainerCheckBox.IsEnabled = true;
+                }
+                else
+                {
+                    ContainerCheckBox.IsEnabled = false;
+                    ContainerCheckBox.IsChecked = false;
+                }
             }
 
             base.OnNavigatedTo(e);

--- a/src/App/FileTransferPage.xaml.cs
+++ b/src/App/FileTransferPage.xaml.cs
@@ -28,19 +28,27 @@ namespace Microsoft.FactoryOrchestrator.UWP
 
         protected override void OnNavigatedTo(NavigationEventArgs e)
         {
-            if (Client.IsLocalHost)
+            if (((App)Application.Current).IsContainerDisabled)
             {
-                ContainerCheckBox.IsChecked = true;
-                ContainerCheckBox.IsEnabled = false;
-            }
-            else if (((App)Application.Current).IsContainerRunning)
-            {
-                ContainerCheckBox.IsChecked = false;
+                ContainerCheckBox.Visibility = Visibility.Collapsed;
             }
             else
             {
-                ContainerCheckBox.IsChecked = false;
-                ContainerCheckBox.IsEnabled = false;
+                ContainerCheckBox.Visibility = Visibility.Visible;
+                if (Client.IsLocalHost)
+                {
+                    ContainerCheckBox.IsChecked = true;
+                    ContainerCheckBox.IsEnabled = false;
+                }
+                else if (((App)Application.Current).IsContainerRunning)
+                {
+                    ContainerCheckBox.IsChecked = false;
+                }
+                else
+                {
+                    ContainerCheckBox.IsChecked = false;
+                    ContainerCheckBox.IsEnabled = false;
+                }
             }
 
             ((App)Application.Current).PropertyChanged += FileTransferPage_AppPropertyChanged;

--- a/src/App/Resources/en-US/Resources.resw
+++ b/src/App/Resources/en-US/Resources.resw
@@ -722,4 +722,20 @@ On retry</value>
     <value>For example: RunAsRDUser.exe c:\windows\regedit.exe</value>
     <comment>Example of how to run win32 gui executables inside the container</comment>
   </data>
+  <data name="ContainerSupport.Text" xml:space="preserve">
+    <value>Container Support Enabled</value>
+    <comment>text field showing if the Service allows container support.</comment>
+  </data>
+  <data name="ContainerRunning.Text" xml:space="preserve">
+    <value>Container Running</value>
+    <comment>text field showing if the Service has a container running.</comment>
+  </data>
+  <data name="NetworkAccess.Text" xml:space="preserve">
+    <value>Network Access Allowed</value>
+    <comment>text field showing if the Service allows network connections.</comment>
+  </data>
+  <data name="ServiceInformation.Text" xml:space="preserve">
+    <value>Factory Orchestrator Service Information</value>
+    <comment>text field header for showing info that relate to what features are enabled / disabled in the Service.</comment>
+  </data>
 </root>

--- a/src/ClientLibrary/FactoryOrchestratorClient.cs
+++ b/src/ClientLibrary/FactoryOrchestratorClient.cs
@@ -493,7 +493,7 @@ namespace Microsoft.FactoryOrchestrator.Client
                 // This is almost certainly due to a client<->server version mismatch
                 ex = new FactoryOrchestratorVersionMismatchException(Resources.IpcInvalidOperationError, ex);
             }
-            else if ((ex is IpcCommunicationException) || (ex.InnerException is System.Net.Sockets.SocketException))
+            else if ((ex is IpcCommunicationException) || (ex is TimeoutException && ex.StackTrace.ToUpperInvariant().Contains("CONNECTTOSERVERASYNC")) || (ex.InnerException is System.Net.Sockets.SocketException))
             {
                 IsConnected = false;
                 ex = new FactoryOrchestratorConnectionException(IpAddress);

--- a/src/ClientLibrary/FactoryOrchestratorClientAutogenerated.cs
+++ b/src/ClientLibrary/FactoryOrchestratorClientAutogenerated.cs
@@ -359,6 +359,27 @@ namespace Microsoft.FactoryOrchestrator.Client
         }
 
         /// <summary>
+        /// Checks if the service supports network access.
+        /// </summary>
+        /// <returns><c>true</c> if the service allows connections over the local network.</returns>
+        public async Task<bool> IsNetworkAccessEnabled()
+        {
+            if (!IsConnected)
+            {
+                throw new FactoryOrchestratorConnectionException(Resources.ClientNotConnected);
+            }
+
+            try
+            {
+                return await _IpcClient.InvokeAsync<bool>(CreateIpcRequest("IsNetworkAccessEnabled"));
+            }
+            catch (Exception ex)
+            {
+                throw CreateIpcException(ex);
+            }
+        }
+
+        /// <summary>
         /// Creates a new TaskList by finding all .exe, .cmd, .bat, .ps1, and TAEF files in a given folder.
         /// </summary>
         /// <param name="path">Path of the directory to search.</param>

--- a/src/CoreLibrary/IPCInterface.cs
+++ b/src/CoreLibrary/IPCInterface.cs
@@ -251,7 +251,6 @@ namespace Microsoft.FactoryOrchestrator.Core
         /// </summary>
         /// <returns><c>true</c> is the service is executing boot tasks.</returns>
         bool IsExecutingBootTasks();
-
         /// <summary>
         /// Determines whether the connected device has a container present and running.
         /// </summary>
@@ -259,12 +258,16 @@ namespace Microsoft.FactoryOrchestrator.Core
         ///   <c>true</c> if container is present and running; otherwise, <c>false</c>.
         /// </returns>
         bool IsContainerRunning();
-
         /// <summary>
         /// Gets a list of Factory Orchestrator App pages that were disabled by OEM Customization.
         /// </summary>
         /// <returns>A list of page tags that should be disabled.</returns>
         List<string> GetDisabledPages();
+        /// <summary>
+        /// Checks if the service supports network access.
+        /// </summary>
+        /// <returns><c>true</c> if the service allows connections over the local network.</returns>
+        bool IsNetworkAccessEnabled();
 
         // TaskList APIs
         /// <summary>

--- a/src/CoreLibrary/IPCInterface.cs
+++ b/src/CoreLibrary/IPCInterface.cs
@@ -58,6 +58,14 @@ namespace Microsoft.FactoryOrchestrator.Core
         /// </summary>
         ContainerDisconnected,
         /// <summary>
+        /// The Factory Orchestrator Service container support is disabled by policy.
+        /// </summary>
+        ContainerDisabled,
+        /// <summary>
+        /// The Factory Orchestrator Service network access is disabled by policy.
+        /// </summary>
+        NetworkAccessDisabled,
+        /// <summary>
         /// An unknown Factory Orchestrator Service event occurred.
         /// </summary>
         Unknown = int.MaxValue

--- a/src/CoreLibrary/Resources/Resources.Designer.cs
+++ b/src/CoreLibrary/Resources/Resources.Designer.cs
@@ -223,7 +223,7 @@ namespace Microsoft.FactoryOrchestrator.Core {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to OS does not support containers. Disabling container support..
+        ///   Looks up a localized string similar to Operating System does not support containers. Disabling container support..
         /// </summary>
         public static string ContainerSupportNotPresent {
             get {

--- a/src/CoreLibrary/Resources/Resources.Designer.cs
+++ b/src/CoreLibrary/Resources/Resources.Designer.cs
@@ -187,7 +187,7 @@ namespace Microsoft.FactoryOrchestrator.Core {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Container support is disabled!.
+        ///   Looks up a localized string similar to Container support is disabled or not supported by the OS!.
         /// </summary>
         public static string ContainerDisabledException {
             get {
@@ -219,6 +219,15 @@ namespace Microsoft.FactoryOrchestrator.Core {
         public static string ContainerFileSendFailed {
             get {
                 return ResourceManager.GetString("ContainerFileSendFailed", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to OS does not support containers. Disabling container support..
+        /// </summary>
+        public static string ContainerSupportNotPresent {
+            get {
+                return ResourceManager.GetString("ContainerSupportNotPresent", resourceCulture);
             }
         }
         

--- a/src/CoreLibrary/Resources/Resources.resx
+++ b/src/CoreLibrary/Resources/Resources.resx
@@ -462,7 +462,7 @@
     <comment>Exception message when a Task the user wants run in the container is of an invalid type</comment>
   </data>
   <data name="ContainerSupportNotPresent" xml:space="preserve">
-    <value>OS does not support containers. Disabling container support.</value>
+    <value>Operating System does not support containers. Disabling container support.</value>
     <comment>Message shown when the operating system doesn't support containers.</comment>
   </data>
 </root>

--- a/src/CoreLibrary/Resources/Resources.resx
+++ b/src/CoreLibrary/Resources/Resources.resx
@@ -450,7 +450,8 @@
     <comment>Error message shown when TaskRun encounters an unhandled exception while running.</comment>
   </data>
   <data name="ContainerDisabledException" xml:space="preserve">
-    <value>Container support is disabled!</value>
+    <value>Container support is disabled or not supported by the OS!</value>
+    <comment>Message shown when a container operation is requested by the user but containers are disabled by policy or the operating system doesn't support containers.</comment>
   </data>
   <data name="WaitingForContainerStart" xml:space="preserve">
     <value>Waiting for the container to be ready...</value>
@@ -459,5 +460,9 @@
   <data name="ContainerTaskTypeException" xml:space="preserve">
     <value>Tasks run in the container must be of type ExecutableTask, BatchFileTask, or PowerShellTask!</value>
     <comment>Exception message when a Task the user wants run in the container is of an invalid type</comment>
+  </data>
+  <data name="ContainerSupportNotPresent" xml:space="preserve">
+    <value>OS does not support containers. Disabling container support.</value>
+    <comment>Message shown when the operating system doesn't support containers.</comment>
   </data>
 </root>

--- a/src/CoreLibrary/ServerExceptions.cs
+++ b/src/CoreLibrary/ServerExceptions.cs
@@ -147,6 +147,38 @@ namespace Microsoft.FactoryOrchestrator.Core
     }
 
     /// <summary>
+    /// An exception denoting that container support is disabled.
+    /// </summary>
+    [JsonObject(MemberSerialization.Fields)]
+    public class FactoryOrchestratorContainerDisabledException : FactoryOrchestratorContainerException
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FactoryOrchestratorContainerDisabledException"/> class.
+        /// </summary>
+        public FactoryOrchestratorContainerDisabledException() : base() { }
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FactoryOrchestratorContainerDisabledException"/> class.
+        /// </summary>
+        /// <param name="message">The message that describes the error.</param>
+        public FactoryOrchestratorContainerDisabledException(string message) : base(message) { }
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FactoryOrchestratorContainerDisabledException"/> class.
+        /// </summary>
+        /// <param name="message">The error message that explains the reason for the exception.</param>
+        /// <param name="innerException">The exception that is the cause of the current exception, or a null reference (Nothing in Visual Basic) if no inner exception is specified.</param>
+        public FactoryOrchestratorContainerDisabledException(string message, Exception innerException) : base(message, innerException) { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FactoryOrchestratorContainerDisabledException"/> class.
+        /// </summary>
+        /// <param name="message">Error message.</param>
+        /// <param name="guid">The GUID this Exception relates to.</param>
+        /// <param name="innerException">Inner Exception(s)</param>
+        public FactoryOrchestratorContainerDisabledException(string message = null, Guid? guid = null, Exception innerException = null) : base(message, guid, innerException)
+        { }
+    }
+
+    /// <summary>
     /// An exception denoting an issue with given FactoryOrchestratorXML file.
     /// </summary>
     [JsonObject(MemberSerialization.Fields)]

--- a/src/Service/ServiceExe.cs
+++ b/src/Service/ServiceExe.cs
@@ -25,9 +25,19 @@ using System.Globalization;
 using JKang.IpcServiceFramework.Hosting;
 using Microsoft.Extensions.Hosting;
 using System.Threading;
+using System.Reflection.Metadata.Ecma335;
 
 namespace Microsoft.FactoryOrchestrator.Service
 {
+    internal static class NativeMethods
+    {
+        [DllImport("KernelBase.dll", SetLastError = false, ExactSpelling = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+#pragma warning disable CA2101 // Specify marshaling for P/Invoke string arguments
+        public static extern bool IsApiSetImplemented([MarshalAs(UnmanagedType.LPStr)] string Contract);
+#pragma warning restore CA2101 // Specify marshaling for P/Invoke string arguments
+    }
+
     public sealed class FOServiceExe
     {
         public static IHost ipcHost { get; internal set; }
@@ -1209,7 +1219,7 @@ namespace Microsoft.FactoryOrchestrator.Service
             {
                 FOService.Instance.ServiceLogger.LogDebug($"{Resources.Start}: GetContainerIpAddresses");
 
-                if (FOService.Instance.DisableContainerSupport)
+                if (!FOService.Instance.IsContainerSupportEnabled)
                 {
                     throw new FactoryOrchestratorContainerDisabledException(Resources.ContainerDisabledException);
                 }
@@ -1277,13 +1287,29 @@ namespace Microsoft.FactoryOrchestrator.Service
             {
                 FOService.Instance.ServiceLogger.LogDebug($"{Resources.Start}: IsContainerRunning");
 
-                if (FOService.Instance.DisableContainerSupport)
+                if (!FOService.Instance.IsContainerSupportEnabled)
                 {
                     throw new FactoryOrchestratorContainerDisabledException(Resources.ContainerDisabledException);
                 }
 
                 bool ret = FOService.Instance.IsContainerConnected;
                 FOService.Instance.ServiceLogger.LogDebug($"{Resources.Finish}: IsContainerRunning");
+                return ret;
+            }
+            catch (Exception e)
+            {
+                FOService.Instance.LogServiceEvent(new ServiceEvent(ServiceEventType.ServiceError, null, e.AllExceptionsToString()));
+                throw;
+            }
+        }
+
+        public bool IsNetworkAccessEnabled()
+        {
+            try
+            {
+                FOService.Instance.ServiceLogger.LogDebug($"{Resources.Start}: IsNetworkAccessEnabled");
+                bool ret = FOService.Instance.IsNetworkAccessEnabled;
+                FOService.Instance.ServiceLogger.LogDebug($"{Resources.Finish}: IsNetworkAccessEnabled");
                 return ret;
             }
             catch (Exception e)
@@ -1412,16 +1438,17 @@ namespace Microsoft.FactoryOrchestrator.Service
         public bool DisableUWPAppsPage { get; private set; }
         public bool DisableManageTasklistsPage { get; private set; }
         public bool DisableFileTransferPage { get; private set; }
-        public bool DisableNetworkAccess { get; private set; }
-        public bool EnableNetworkAccess { get; private set; }
+        public bool IsNetworkAccessEnabled { get => _networkAccessEnabled && !_networkAccessDisabled; }
         public int ServiceNetworkPort { get; private set; }
         public bool RunInitialTaskListsOnFirstBoot { get; private set; }
-        public bool DisableContainerSupport { get; private set; }
+        public bool IsContainerSupportEnabled { get; private set; }
 
         public bool IsContainerConnected => _containerClient?.IsConnected ?? false;
         public Guid ContainerGuid { get; private set; }
         public IPAddress ContainerIpAddress { get; private set; }
         private System.Threading.CancellationTokenSource _containerHeartbeatToken;
+        private bool _networkAccessEnabled;
+        private bool _networkAccessDisabled;
 
         /// <summary>
         /// List of apps to enable local loopback on.
@@ -1516,7 +1543,6 @@ namespace Microsoft.FactoryOrchestrator.Service
         /// </summary>
         public void Start(bool forceUserTaskRerun)
         {
-            bool networkAccessEnabled = false;
             // Execute "first run" tasks. They do nothing if already run, but might need to run every boot on a state separated WCOS image.
             ExecuteServerBootTasks();
 
@@ -1534,17 +1560,12 @@ namespace Microsoft.FactoryOrchestrator.Service
                 }
             }
 
-            if (EnableNetworkAccess && !DisableNetworkAccess) 
-            {
-                networkAccessEnabled = true;
-            }
-
             // Start IPC server on port 45684. Only start after all boot tasks are complete.
-            FOServiceExe.ipcHost = FOServiceExe.CreateHost(null, networkAccessEnabled);
+            FOServiceExe.ipcHost = FOServiceExe.CreateHost(null, IsNetworkAccessEnabled);
             _ipcCancellationToken = new System.Threading.CancellationTokenSource();
             FOServiceExe.ipcHost.RunAsync(_ipcCancellationToken.Token);
 
-            if (networkAccessEnabled)
+            if (IsNetworkAccessEnabled)
             {
                 ServiceLogger.LogInformation($"{Resources.NetworkAccessEnabled}\n");
             }
@@ -1883,7 +1904,7 @@ namespace Microsoft.FactoryOrchestrator.Service
 
         public async Task ConnectToContainer()
         {
-            if (DisableContainerSupport)
+            if (!IsContainerSupportEnabled)
             {
                 throw new FactoryOrchestratorContainerException(Resources.ContainerDisabledException);
             }
@@ -2295,7 +2316,7 @@ namespace Microsoft.FactoryOrchestrator.Service
             _taskExecutionManager = new TaskManager(TaskManagerLogFolder, Path.Combine(FOServiceExe.ServiceLogFolder, "FactoryOrchestratorKnownTaskLists.xml"));
             _taskExecutionManager.OnTaskManagerEvent += HandleTaskManagerEvent;
 
-            if (!DisableContainerSupport)
+            if (IsContainerSupportEnabled)
             {
                 // Start container heartbeat thread
                 _containerHeartbeatToken = new System.Threading.CancellationTokenSource();
@@ -2626,20 +2647,20 @@ namespace Microsoft.FactoryOrchestrator.Service
         {
             try
             {
-                DisableNetworkAccess = Convert.ToBoolean(GetValueFromRegistry(_disableNetworkAccessValue) ?? throw new ArgumentNullException("GetValueFromRegistry(_disableNetworkAccessValue)"), CultureInfo.InvariantCulture);
+                _networkAccessDisabled = Convert.ToBoolean(GetValueFromRegistry(_disableNetworkAccessValue) ?? throw new ArgumentNullException("GetValueFromRegistry(_disableNetworkAccessValue)"), CultureInfo.InvariantCulture);
             }
             catch (Exception)
             {
-                DisableNetworkAccess = true;
+                _networkAccessDisabled = true;
             }
 
             try
             {
-                EnableNetworkAccess = Convert.ToBoolean(GetValueFromRegistry(_enableNetworkAccessValue) ?? throw new ArgumentNullException("GetValueFromRegistry(_enableNetworkAccessValue)"), CultureInfo.InvariantCulture);
+                _networkAccessEnabled = Convert.ToBoolean(GetValueFromRegistry(_enableNetworkAccessValue) ?? throw new ArgumentNullException("GetValueFromRegistry(_enableNetworkAccessValue)"), CultureInfo.InvariantCulture);
             }
             catch (Exception)
             {
-                EnableNetworkAccess = false;
+                _networkAccessEnabled = false;
             }
 
             try
@@ -2707,19 +2728,19 @@ namespace Microsoft.FactoryOrchestrator.Service
 
             try
             {
-                DisableContainerSupport = Convert.ToBoolean(GetValueFromRegistry(_disableContainerValue) ?? throw new ArgumentNullException("GetValueFromRegistry(_disableContainerValue)"), CultureInfo.InvariantCulture);
+                IsContainerSupportEnabled = !Convert.ToBoolean(GetValueFromRegistry(_disableContainerValue) ?? throw new ArgumentNullException("GetValueFromRegistry(_disableContainerValue)"), CultureInfo.InvariantCulture);
             }
             catch (Exception)
             {
-                DisableContainerSupport = false;
+                IsContainerSupportEnabled = true;
             }
 
-            if (!File.Exists(Path.Combine(Environment.GetEnvironmentVariable("windir"), "system32", "cmservice.dll")))
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows) || !NativeMethods.IsApiSetImplemented("api-ms-win-containers-cmclient-l1-4-0"))
             {
-                // Missing required binary for container support. Disable it.
-                // TODO: this assumes we are running on a Windows OS
+                // Missing required ApiSet for container support. Disable it.
+                // Currently container support is restricted to Windows.
                 ServiceLogger.LogInformation(Resources.ContainerSupportNotPresent);
-                DisableContainerSupport = true;
+                IsContainerSupportEnabled = false;
             }
 
             String loopbackAppsString;

--- a/src/Service/ServiceExe.cs
+++ b/src/Service/ServiceExe.cs
@@ -2714,6 +2714,14 @@ namespace Microsoft.FactoryOrchestrator.Service
                 DisableContainerSupport = false;
             }
 
+            if (!File.Exists(Path.Combine(Environment.GetEnvironmentVariable("windir"), "system32", "cmservice.dll")))
+            {
+                // Missing required binary for container support. Disable it.
+                // TODO: this assumes we are running on a Windows OS
+                ServiceLogger.LogInformation(Resources.ContainerSupportNotPresent);
+                DisableContainerSupport = true;
+            }
+
             String loopbackAppsString;
             try
             {

--- a/src/custom.props
+++ b/src/custom.props
@@ -3,7 +3,7 @@
   <!-- Set the major and minor build numbers here, used by PackageES and SetSourceVersion.ps1 -->
   <PropertyGroup Label="Version">
      <VersionMajor>8</VersionMajor>
-     <VersionMinor>1</VersionMinor>
+     <VersionMinor>2</VersionMinor>
      <VersionInfoProductName>Factory Orchestrator</VersionInfoProductName>
  </PropertyGroup>
 </Project>


### PR DESCRIPTION
The "Run In Container" checkboxes in the FO app are creating confusion as users see them greyed out when the image has no container support. This change hides the boxes entirely if container support is disabled in the Service by policy.