### PR TITLE
Update nuget dependences

### DIFF
--- a/src/ClientLibrary/Microsoft.FactoryOrchestrator.Client.csproj
+++ b/src/ClientLibrary/Microsoft.FactoryOrchestrator.Client.csproj
@@ -16,7 +16,7 @@
     <DefaultDocumentationFolder>$(OutputRootPath)/DefaultDocumentation/ClientLibrary</DefaultDocumentationFolder>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="DefaultDocumentation" Version="0.6.13">
+    <PackageReference Include="DefaultDocumentation" Version="0.6.15">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/src/CoreLibrary/Microsoft.FactoryOrchestrator.Core.csproj
+++ b/src/CoreLibrary/Microsoft.FactoryOrchestrator.Core.csproj
@@ -30,7 +30,7 @@
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="System.Private.Uri" Version="4.3.2" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
-    <PackageReference Include="DefaultDocumentation" Version="0.6.13">
+    <PackageReference Include="DefaultDocumentation" Version="0.6.15">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/src/common.props
+++ b/src/common.props
@@ -83,7 +83,7 @@
 
   <!-- .NET Core package references -->
   <ItemGroup Condition="'$(TargetPlatformIdentifier)' == ''">
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.0">
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
- Fixes frequent exception when building documentation
- FxCop 3.3.0 was deprecated