### PR TITLE
Disable EventLog and EventSource (ETW) providers

### DIFF
--- a/src/common.props
+++ b/src/common.props
@@ -3,7 +3,7 @@
 
   <!-- Assembly, App, Package version for all non-OSS files. Uses SemVer. -->
   <PropertyGroup Label="Version">
-    <VersionPrefix>10.1.0</VersionPrefix>
+    <VersionPrefix>10.1.1</VersionPrefix>
   </PropertyGroup>
 
   <!-- Common packaging properties -->


### PR DESCRIPTION
fixes Bug 33062766: [Watson Failure] caused by CLR_EXCEPTION_System.InvalidOperationException_80131509_Microsoft.Extensions.Logging.EventLog.dll!Microsoft.Extensions.Logging.EventLog.EventLogLogger.Log[[Microsoft.Extensions.Logging.FormattedLogValues,_Microsoft.Extensions.Lo...