### PR TITLE
An element is focused through the entire main page taborder

### DIFF
--- a/src/App/EditPage.xaml
+++ b/src/App/EditPage.xaml
@@ -117,7 +117,22 @@
         </StackPanel>
 
         <TextBlock x:Name="BgTasksHeader" x:Uid="BgTasksHeader" Grid.Row="3" Grid.Column="1" Style="{StaticResource TitleTextBlockStyle}" HorizontalAlignment="Left" Visibility="Collapsed"/>
-        <ListView x:Name="BgTaskListView" Grid.Row="4"  Grid.Column="1" SelectionMode="None" AllowDrop="True" IsItemClickEnabled="False" CanDragItems="True" CanReorderItems="True" IsSwipeEnabled="True" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" ScrollViewer.VerticalScrollMode="Enabled" DragItemsCompleted="TaskListView_DragCompleted" MinHeight="1" MinWidth="1">
+        <ListView 
+            x:Name="BgTaskListView" 
+            Grid.Row="4"  
+            Grid.Column="1" 
+            SelectionMode="None" 
+            AllowDrop="True" 
+            IsItemClickEnabled="False" 
+            CanDragItems="True" 
+            CanReorderItems="True" 
+            IsSwipeEnabled="True" 
+            HorizontalAlignment="Stretch" 
+            VerticalAlignment="Stretch" 
+            ScrollViewer.VerticalScrollMode="Enabled" 
+            DragItemsCompleted="TaskListView_DragCompleted" 
+            MinHeight="1" 
+            MinWidth="1">
             <ListView.Resources>
                 <Style TargetType="ListViewItem">
                     <Setter Property="Template">
@@ -154,7 +169,20 @@
         </ListView>
 
         <TextBlock x:Name="TasksHeader" x:Uid="TasksHeader" Grid.Row="5" Grid.Column="1" Style="{StaticResource TitleTextBlockStyle}" HorizontalAlignment="Left" Visibility="Collapsed"/>
-        <ListView x:Name="TaskListView" Grid.Row="6"  Grid.Column="1" SelectionMode="None" AllowDrop="True" IsItemClickEnabled="False" CanDragItems="True" CanReorderItems="True" IsSwipeEnabled="True" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" ScrollViewer.VerticalScrollMode="Enabled" DragItemsCompleted="TaskListView_DragCompleted">
+        <ListView 
+            x:Name="TaskListView" 
+            Grid.Row="6"  
+            Grid.Column="1" 
+            SelectionMode="Single" 
+            AllowDrop="True" 
+            IsItemClickEnabled="False" 
+            CanDragItems="True" 
+            CanReorderItems="True" 
+            IsSwipeEnabled="True" 
+            HorizontalAlignment="Stretch" 
+            VerticalAlignment="Stretch" 
+            ScrollViewer.VerticalScrollMode="Enabled" 
+            DragItemsCompleted="TaskListView_DragCompleted">
         <ListView.Resources>
             <Style TargetType="ListViewItem">
                 <Setter Property="Template">

--- a/src/App/MainPage.xaml
+++ b/src/App/MainPage.xaml
@@ -144,10 +144,7 @@
                     <muxc:NavigationViewItem Tag="wdp" TabIndex="0" x:Uid="WDP" Icon="SwitchApps"/>
                     <muxc:NavigationViewItem Tag="about" TabIndex="0" x:Uid="About" Icon="Help"/>
                 </muxc:NavigationView.MenuItems>
-                <muxc:NavigationView.FooterMenuItems>
-
-                </muxc:NavigationView.FooterMenuItems>
-                <Frame x:Name="ContentFrame" IsTabStop="True" Padding="12" />
+                <Frame x:Name="ContentFrame" Padding="12" />
             </muxc:NavigationView>
         </Grid>
     </Grid>


### PR DESCRIPTION
### **_Removed tab stop on content frame. now focus is kept through ensure tab-order_**
**Additionally**: did some refactoring to increase code readability