### PR TITLE
Made console error ouput WCAG 2.2 compliant by ensuring a contrast ratio of 4.5 or higher

### DIFF
--- a/src/App/ConsolePage.xaml.cs
+++ b/src/App/ConsolePage.xaml.cs
@@ -443,7 +443,6 @@ namespace Microsoft.FactoryOrchestrator.UWP
                 if (isError)
                 {
                     textBlock.FontWeight = Windows.UI.Text.FontWeights.Bold;
-                    textBlock.Foreground = new SolidColorBrush(Windows.UI.Colors.Red);
                 }
 
                 if (OutputStack.Children.Count >= MaxBlocks)


### PR DESCRIPTION
### **Returned text color on error to be theme-dependent**
Using system resources (default behavior) for text allows the styling to be theme-dependent. It also affects styling at run-time. 
**Original issue**: hard coded red text _(RGB: 255,0,0)_  does not achieve a satisfactory contrast ratio on an all-white background (light mode).
Removing the hard coded text coloring allows console error output to change color with the user's theme. 
WCAG Guidelines: (https://www.w3.org/TR/WCAG22/#contrast-minimum) 