### PR TITLE
Make EditPage and MainPage responsive and enable future efforts 

### DIFF
--- a/src/App/App.xaml
+++ b/src/App/App.xaml
@@ -4,6 +4,20 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:local="using:Microsoft.FactoryOrchestrator.UWP">
     <Application.Resources>
-        <XamlControlsResources xmlns="using:Microsoft.UI.Xaml.Controls" />
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <XamlControlsResources xmlns="using:Microsoft.UI.Xaml.Controls" />
+                <!-- Other merged dictionaries here -->
+            </ResourceDictionary.MergedDictionaries>
+            <!-- Other app resources here -->
+          
+            <!--  Window width adaptive breakpoints.  -->
+            <x:Double x:Key="MinWindowBreakpoint">0</x:Double>
+            <x:Double x:Key="MediumWindowBreakpoint">800</x:Double>
+            <x:Double x:Key="LargeWindowBreakpoint">1008</x:Double>
+        </ResourceDictionary>
+        
     </Application.Resources>
+    
+    
 </Application>

--- a/src/App/EditPage.xaml
+++ b/src/App/EditPage.xaml
@@ -7,6 +7,7 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d"
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+    
     <Page.Resources>
         <Flyout x:Name="EditFlyout" x:Key="EditFlyout" LightDismissOverlayMode="On">
             <Grid x:Name="FlyoutGrid">
@@ -60,6 +61,29 @@
     </Page.Resources>
     
     <Grid x:Name="LayoutRoot" Width="Auto" Height="Auto" HorizontalAlignment="Stretch" Margin="50,50,50,50" VerticalAlignment="Stretch">
+        <VisualStateManager.VisualStateGroups>
+            <!--  Visual states reflect the application's window size  -->
+            <VisualStateGroup x:Name="LayoutVisualStates">
+                <VisualState x:Name="WideLayout">
+                    <VisualState.StateTriggers>
+                        <AdaptiveTrigger MinWindowWidth="{StaticResource MediumWindowBreakpoint}" />
+                    </VisualState.StateTriggers>
+                    <VisualState.Setters />
+                </VisualState>
+                <VisualState x:Name="NarrowLayout">
+                    <VisualState.StateTriggers>
+                        <AdaptiveTrigger MinWindowWidth="0" />
+                    </VisualState.StateTriggers>
+                    <VisualState.Setters>
+                        <Setter Target="LayoutRoot.Margin" Value="20" />
+                        <Setter Target="TaskListHeaderContainer.Orientation" Value="Vertical" />
+                        <Setter Target="TaskListOptions.Orientation" Value="Vertical" />
+                        <Setter Target="TaskTypeOptionsGroup1.Orientation" Value="Vertical" />
+                        <Setter Target="TaskTypeOptionsGroup2.Orientation" Value="Vertical"/>
+                    </VisualState.Setters>
+                </VisualState>
+            </VisualStateGroup>
+        </VisualStateManager.VisualStateGroups>
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
@@ -74,8 +98,8 @@
             <ColumnDefinition Width="*"/>
         </Grid.ColumnDefinitions>
         <Button x:Name="BackButton" x:Uid="BackButton" Grid.Row="0" Grid.Column="0" Click="Back_Click" Style="{StaticResource NavigationBackButtonNormalStyle}" />
-        <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Grid.Row="0" Grid.Column="1" Spacing="10">
-            <TextBlock x:Name="TaskListHeader" Style="{StaticResource SubheaderTextBlockStyle}" VerticalAlignment="Center"/>
+        <StackPanel x:Name="TaskListHeaderContainer" Orientation="Horizontal" HorizontalAlignment="Center" Grid.Row="0" Grid.Column="1" Spacing="10">
+            <TextBlock x:Name="TaskListHeader" Style="{StaticResource SubheaderTextBlockStyle}" VerticalAlignment="Center" TextWrapping="Wrap"/>
             <Button x:Name="EditListNameButton" x:Uid="EditListNameButton" VerticalAlignment="Center">
                 <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" Glyph="&#xE8AC;"/>
                 <Button.Flyout>
@@ -97,19 +121,19 @@
             </Button>
         </StackPanel>
 
-        <StackPanel Orientation="Horizontal" Grid.Row="1" Grid.Column="1" Grid.ColumnSpan="2" Spacing="10" Padding="10">
+        <StackPanel x:Name="TaskListOptions" Orientation="Horizontal" Grid.Row="1" Grid.Column="1" Grid.ColumnSpan="2" Spacing="10" Padding="10">
             <TextBlock x:Name="TaskListOpt" x:Uid="TaskListOpt" Style="{StaticResource SubtitleTextBlockStyle}"/>
             <CheckBox x:Name="ParallelCheck" x:Uid="ParallelCheck" IsChecked="False" Click="ListCheck_Checked" IsThreeState="False"/>
             <CheckBox x:Name="BlockingCheck" x:Uid="BlockingCheck" IsChecked="False" Click="ListCheck_Checked" IsThreeState="False"/>
             <CheckBox x:Name="TerminateBgTasksCheck" x:Uid="TerminateBgTasksCheck" IsChecked="False" Click="ListCheck_Checked" IsThreeState="False"/>
         </StackPanel>
-        <StackPanel Orientation="Vertical" Grid.Row="2" Grid.Column="1" Grid.ColumnSpan="2">
-            <StackPanel Orientation="Horizontal" Spacing="10" Padding="10,10,0,0">
+        <StackPanel  Orientation="Vertical" Grid.Row="2" Grid.Column="1" Grid.ColumnSpan="2">
+            <StackPanel x:Name="TaskTypeOptionsGroup1" Orientation="Horizontal" Spacing="10" Padding="10,10,0,0">
                 <Button x:Name="NewExecutableButton" x:Uid="NewExecutableButton" Click="NewExecutableButton_Click"/>
                 <Button x:Name="NewPSButton" x:Uid="NewPSButton" Click="NewPSButton_Click"/>
                 <Button x:Name="NewCMDButton" x:Uid="NewCMDButton" Click="NewCMDButton_Click"/>
             </StackPanel>
-            <StackPanel Orientation="Horizontal" Spacing="10" Padding="10,10,0,0">
+            <StackPanel x:Name="TaskTypeOptionsGroup2" Orientation="Horizontal" Spacing="10" Padding="10,10,0,0">
                 <Button x:Name="NewTAEFButton" x:Uid="NewTAEFButton" Click="NewTAEFButton_Click"/>
                 <Button x:Name="NewUWPButton" x:Uid="NewUWPButton" Click="NewUWPButton_Click"/>
                 <Button x:Name="NewExternalButton" x:Uid="NewExternalButton" Click="NewExternalButton_Click"/>
@@ -117,7 +141,22 @@
         </StackPanel>
 
         <TextBlock x:Name="BgTasksHeader" x:Uid="BgTasksHeader" Grid.Row="3" Grid.Column="1" Style="{StaticResource TitleTextBlockStyle}" HorizontalAlignment="Left" Visibility="Collapsed"/>
-        <ListView x:Name="BgTaskListView" Grid.Row="4"  Grid.Column="1" SelectionMode="None" AllowDrop="True" IsItemClickEnabled="False" CanDragItems="True" CanReorderItems="True" IsSwipeEnabled="True" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" ScrollViewer.VerticalScrollMode="Enabled" DragItemsCompleted="TaskListView_DragCompleted" MinHeight="1" MinWidth="1">
+        <ListView 
+            x:Name="BgTaskListView" 
+            Grid.Row="4"  
+            Grid.Column="1" 
+            SelectionMode="None" 
+            AllowDrop="True" 
+            IsItemClickEnabled="False" 
+            CanDragItems="True" 
+            CanReorderItems="True" 
+            IsSwipeEnabled="True" 
+            HorizontalAlignment="Stretch" 
+            VerticalAlignment="Stretch" 
+            ScrollViewer.VerticalScrollMode="Enabled" 
+            DragItemsCompleted="TaskListView_DragCompleted" 
+            MinHeight="1" 
+            MinWidth="1">
             <ListView.Resources>
                 <Style TargetType="ListViewItem">
                     <Setter Property="Template">
@@ -153,8 +192,21 @@
             </ListView.ItemTemplate>
         </ListView>
 
-        <TextBlock x:Name="TasksHeader" x:Uid="TasksHeader" Grid.Row="5" Grid.Column="1" Style="{StaticResource TitleTextBlockStyle}" HorizontalAlignment="Left" Visibility="Collapsed"/>
-        <ListView x:Name="TaskListView" Grid.Row="6"  Grid.Column="1" SelectionMode="None" AllowDrop="True" IsItemClickEnabled="False" CanDragItems="True" CanReorderItems="True" IsSwipeEnabled="True" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" ScrollViewer.VerticalScrollMode="Enabled" DragItemsCompleted="TaskListView_DragCompleted">
+        <TextBlock x:Name="TasksHeader" x:Uid="TasksHeader" Grid.Row="5" Grid.Column="1" Style="{StaticResource TitleTextBlockStyle}" HorizontalAlignment="Left" Visibility="Collapsed" TextWrapping="Wrap"/>
+        <ListView 
+            x:Name="TaskListView" 
+            Grid.Row="6"  
+            Grid.Column="1" 
+            SelectionMode="None" 
+            AllowDrop="True" 
+            IsItemClickEnabled="False" 
+            CanDragItems="True" 
+            CanReorderItems="True" 
+            IsSwipeEnabled="True" 
+            HorizontalAlignment="Stretch" 
+            VerticalAlignment="Stretch" 
+            ScrollViewer.VerticalScrollMode="Enabled" 
+            DragItemsCompleted="TaskListView_DragCompleted">
         <ListView.Resources>
             <Style TargetType="ListViewItem">
                 <Setter Property="Template">

--- a/src/App/MainPage.xaml
+++ b/src/App/MainPage.xaml
@@ -11,6 +11,44 @@
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 
     <Grid>
+        <VisualStateManager.VisualStateGroups>
+            <VisualStateGroup>
+                <VisualState x:Name="WideLayout">
+                    <VisualState.StateTriggers>
+                        <AdaptiveTrigger MinWindowWidth="1080"/>
+                    </VisualState.StateTriggers>
+                    <VisualState.Setters/>
+
+                </VisualState>
+                <VisualState x:Name="MediumLayout">
+                    <VisualState.StateTriggers>
+                        <AdaptiveTrigger MinWindowWidth="600"/>
+                    </VisualState.StateTriggers>
+                    <VisualState.Setters>
+                        <Setter Target="MainControlPanel.Padding" Value="0"></Setter>
+                        <Setter Target="MainControlPanel.HorizontalAlignment" Value="Center"></Setter>
+                        <Setter Target="ContentFrame.Padding" Value="1"></Setter>
+                        <Setter Target="HeaderPanel.Orientation" Value="Vertical"></Setter>
+                        <Setter Target="NavView.PaneDisplayMode" Value="LeftCompact"></Setter>
+                    </VisualState.Setters>
+                </VisualState>
+                <VisualState x:Name="SmallLayout">
+                    <VisualState.StateTriggers>
+                        <AdaptiveTrigger MinWindowWidth="0"/>
+                    </VisualState.StateTriggers>
+                    <VisualState.Setters>
+                        <Setter Target="MainControlPanel.Padding" Value="0"></Setter>
+                        <Setter Target="MainControlPanel.HorizontalAlignment" Value="Left"></Setter>
+                        <Setter Target="ContentFrame.Padding" Value="1"></Setter>
+                        <Setter Target="HeaderPanel.Orientation" Value="Vertical"></Setter>
+                        <Setter Target="ButtonPanel.HorizontalAlignment" Value="Left"></Setter>
+                        <Setter Target="Flipper.Orientation" Value="Vertical"></Setter>
+                        <Setter Target="NavView.PaneDisplayMode" Value="LeftMinimal"></Setter>
+
+                    </VisualState.Setters>
+                </VisualState>
+            </VisualStateGroup>
+        </VisualStateManager.VisualStateGroups>
         <Grid Grid.Row="0"  VerticalAlignment="Top">
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="*"/>
@@ -22,113 +60,110 @@
         </Grid>
 
         <Grid x:Name="LayoutRoot" Width="Auto" Height="Auto" HorizontalAlignment="Stretch" Margin="30,40,30,0" VerticalAlignment="Stretch">
+            
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto" />
                 <RowDefinition Height="Auto" />
                 <RowDefinition Height="10" />
                 <RowDefinition Height="*" />
             </Grid.RowDefinitions>
-            <Grid Grid.Row="0">
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="*"></ColumnDefinition>
-                    <ColumnDefinition Width="*"></ColumnDefinition>
-                </Grid.ColumnDefinitions>
-                <StackPanel Orientation="Horizontal">
-                    
-                    <TextBlock x:Name="Header" x:Uid="FactoryOrchestrator" Grid.Column="0" Text="" VerticalAlignment="Center" HorizontalAlignment="Left" FontWeight="Bold" Style="{StaticResource TitleTextBlockStyle}"/>
-                </StackPanel>
-                <Frame HorizontalAlignment="Right" Grid.Column="1">
-                    <StackPanel Orientation="Horizontal">
-                        <StackPanel Orientation="Vertical" VerticalAlignment="Center" HorizontalAlignment="Left" Margin="5">
-                            <TextBlock x:Name="NetworkName" Text="" Style="{StaticResource CaptionTextBlockStyle}" VerticalAlignment="Center" TextWrapping="Wrap" IsTextSelectionEnabled="True"/>
-                            <TextBlock x:Name="NetworkIp" Text="" Style="{StaticResource CaptionTextBlockStyle}" VerticalAlignment="Center" TextWrapping="Wrap" IsTextSelectionEnabled="True"/>
-                        </StackPanel>
-                        <StackPanel Orientation="Vertical" VerticalAlignment="Center" HorizontalAlignment="Left" Margin="5">
-                            <TextBlock x:Name="OSVersionHeader" Text=""  VerticalAlignment="Center" HorizontalAlignment="Left" TextWrapping="Wrap" Style="{StaticResource CaptionTextBlockStyle}" IsTextSelectionEnabled="True"/>
-                            <TextBlock x:Name="OEMVersionHeader" Text="" VerticalAlignment="Center" HorizontalAlignment="Left" TextWrapping="Wrap" Style="{StaticResource CaptionTextBlockStyle}" IsTextSelectionEnabled="True"/>
-                        </StackPanel>
-                        <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
-                            <StackPanel.BorderBrush>
-                                <SolidColorBrush Color="{ThemeResource SystemAltLowColor}"/>
-                            </StackPanel.BorderBrush>
-                            <Button x:Name="NetworkButton" x:Uid="NetworkButton" Visibility="Visible" Padding="5" Margin="0">
-                                <StackPanel Orientation="Horizontal">
-                                    <TextBlock FontFamily="Segoe MDL2 Assets" Text="&#xEDA3;" FontSize="30" VerticalAlignment="Center" />
-                                </StackPanel>
-                                <Button.Flyout>
-                                    <Flyout x:Name="NetworkFlyout" Opening="NetworkFlyout_Opening">
-                                        <StackPanel Orientation="Vertical" HorizontalAlignment="Center">
-                                            <TextBlock Style="{StaticResource FlyoutPickerTitleTextBlockStyle}" x:Uid="IpHeader" Text="" HorizontalAlignment="Center"/>
-                                            <StackPanel x:Name="NetworkStackPanel" Orientation="Vertical" HorizontalAlignment="Center">
+
+            <StackPanel x:Name="HeaderPanel" Orientation="Horizontal">
+                <TextBlock x:Name="Header" x:Uid="FactoryOrchestrator" Grid.Column="0" Text="" TextWrapping="Wrap" VerticalAlignment="Center" HorizontalAlignment="Left" FontWeight="Bold" Style="{StaticResource TitleTextBlockStyle}"/>
+                <StackPanel x:Name = "MainControlPanel" Orientation="Horizontal" HorizontalAlignment="Center" Padding="40,0,0,0" Grid.Column="1" Grid.Row="0">
+                        <StackPanel x:Name="Flipper" Orientation="Horizontal">
+                            <StackPanel Orientation="Vertical" VerticalAlignment="Center" HorizontalAlignment="Left" Margin="5">
+                                <TextBlock x:Name="NetworkName" Text="" Style="{StaticResource CaptionTextBlockStyle}" VerticalAlignment="Center" TextWrapping="Wrap" IsTextSelectionEnabled="True"/>
+                                <TextBlock x:Name="NetworkIp" Text="" Style="{StaticResource CaptionTextBlockStyle}" VerticalAlignment="Center" TextWrapping="Wrap" IsTextSelectionEnabled="True"/>
+                            </StackPanel>
+                            <StackPanel Orientation="Vertical" VerticalAlignment="Center" HorizontalAlignment="Left" Margin="5">
+                                <TextBlock x:Name="OSVersionHeader" Text=""  VerticalAlignment="Center" HorizontalAlignment="Left" TextWrapping="Wrap" Style="{StaticResource CaptionTextBlockStyle}" IsTextSelectionEnabled="True"/>
+                                <TextBlock x:Name="OEMVersionHeader" Text="" VerticalAlignment="Center" HorizontalAlignment="Left" TextWrapping="Wrap" Style="{StaticResource CaptionTextBlockStyle}" IsTextSelectionEnabled="True"/>
+                            </StackPanel>
+                            <StackPanel x:Name="ButtonPanel" Orientation="Horizontal" HorizontalAlignment="Right">
+                                <StackPanel.BorderBrush>
+                                    <SolidColorBrush Color="{ThemeResource SystemAltLowColor}"/>
+                                </StackPanel.BorderBrush>
+                                <Button x:Name="NetworkButton" x:Uid="NetworkButton" Visibility="Visible" Padding="5" Margin="0">
+                                    <StackPanel Orientation="Horizontal">
+                                        <TextBlock FontFamily="Segoe MDL2 Assets" Text="&#xEDA3;" FontSize="30" VerticalAlignment="Center" />
+                                    </StackPanel>
+                                    <Button.Flyout>
+                                        <Flyout x:Name="NetworkFlyout" Opening="NetworkFlyout_Opening">
+                                            <StackPanel Orientation="Vertical" HorizontalAlignment="Center">
+                                                <TextBlock Style="{StaticResource FlyoutPickerTitleTextBlockStyle}" x:Uid="IpHeader" Text="" HorizontalAlignment="Center"/>
+                                                <StackPanel x:Name="NetworkStackPanel" Orientation="Vertical" HorizontalAlignment="Center">
+                                                </StackPanel>
                                             </StackPanel>
-                                        </StackPanel>
-                                    </Flyout>
-                                </Button.Flyout>
-                            </Button>
-                            <Button x:Name="SettingsButton" x:Uid="SettingsButton" Visibility="Visible" Padding="5" Margin="5,0,0,0">
-                                <StackPanel Orientation="Horizontal">
-                                    <TextBlock FontFamily="Segoe MDL2 Assets" Text="&#xE713;" FontSize="30" VerticalAlignment="Center" />
-                                </StackPanel>
-                                <Button.Flyout>
-                                    <Flyout x:Name="SettingsFlyout" Opening="SettingsFlyout_Opening">
-                                        <StackPanel Orientation="Vertical" HorizontalAlignment="Center">
-                                            <TextBlock Style="{StaticResource FlyoutPickerTitleTextBlockStyle}" x:Uid="SettingsHeader" HorizontalAlignment="Center"/>
-                                            <HyperlinkButton x:Uid="SettingsSubHeader" NavigateUri="https://microsoft.github.io/FactoryOrchestrator/use-the-factory-orchestrator-app#app-settings" HorizontalAlignment="Center"/>
-                                            <StackPanel x:Name="SettingsStackPanel" Orientation="Vertical" HorizontalAlignment="Left">
-                                                <CheckBox x:Name="SettingsTrackExecution" x:Uid="SettingsTrackExecution" IsThreeState="False" IsChecked="True" Checked="SettingsTrackExecution_Checked" Unchecked="SettingsTrackExecution_Checked" />
-                                                <CheckBox x:Name="SettingsShowExternalTasks" x:Uid="SettingsShowExternalTasks" IsThreeState="False" IsChecked="True" Checked="SettingsShowExternalTasks_Checked" Unchecked="SettingsShowExternalTasks_Checked" />
+                                        </Flyout>
+                                    </Button.Flyout>
+                                </Button>
+                                <Button x:Name="SettingsButton" x:Uid="SettingsButton" Visibility="Visible" Padding="5" Margin="5,0,0,0">
+                                    <StackPanel Orientation="Horizontal">
+                                        <TextBlock FontFamily="Segoe MDL2 Assets" Text="&#xE713;" FontSize="30" VerticalAlignment="Center" />
+                                    </StackPanel>
+                                    <Button.Flyout>
+                                        <Flyout x:Name="SettingsFlyout" Opening="SettingsFlyout_Opening">
+                                            <StackPanel Orientation="Vertical" HorizontalAlignment="Center">
+                                                <TextBlock Style="{StaticResource FlyoutPickerTitleTextBlockStyle}" x:Uid="SettingsHeader" HorizontalAlignment="Center"/>
+                                                <HyperlinkButton x:Uid="SettingsSubHeader" NavigateUri="https://microsoft.github.io/FactoryOrchestrator/use-the-factory-orchestrator-app#app-settings" HorizontalAlignment="Center"/>
+                                                <StackPanel x:Name="SettingsStackPanel" Orientation="Vertical" HorizontalAlignment="Left">
+                                                    <CheckBox x:Name="SettingsTrackExecution" x:Uid="SettingsTrackExecution" IsThreeState="False" IsChecked="True" Checked="SettingsTrackExecution_Checked" Unchecked="SettingsTrackExecution_Checked" />
+                                                    <CheckBox x:Name="SettingsShowExternalTasks" x:Uid="SettingsShowExternalTasks" IsThreeState="False" IsChecked="True" Checked="SettingsShowExternalTasks_Checked" Unchecked="SettingsShowExternalTasks_Checked" />
+                                                </StackPanel>
                                             </StackPanel>
-                                        </StackPanel>
-                                    </Flyout>
-                                </Button.Flyout>
-                            </Button>
-                            <Button x:Name="ExitButton" AutomationProperties.LabeledBy="{Binding ElementName=ExitText}" Padding="5" Margin="5,0,0,0">
-                                <StackPanel Orientation="Horizontal">
-                                    <TextBlock FontFamily="Segoe MDL2 Assets" Text="&#xE711;" FontSize="30" VerticalAlignment="Center" />
-                                </StackPanel>
-                                <Button.Flyout>
-                                    <Flyout x:Name="ExitFlyout" Closed="ExitFlyout_Closed">
-                                        <StackPanel>
-                                            <TextBlock x:Name="ExitText" x:Uid="ExitText" TextWrapping="Wrap" Style="{ThemeResource FlyoutPickerTitleTextBlockStyle}" HorizontalAlignment="Center" Margin="5"/>
-                                            <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
-                                                <Button x:Name="ConfirmExit" Padding="8" Margin="10,5" Click="ConfirmExit_Click" AutomationProperties.LabeledBy="{Binding ElementName=ExitButtonText}">
-                                                    <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
-                                                        <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" Glyph="&#xE711;"/>
-                                                        <TextBlock x:Name="ExitButtonText" x:Uid="Exit" Padding="5,0" TextWrapping="Wrap"/>
-                                                    </StackPanel>
-                                                </Button>
-                                                <Button x:Name="ConfirmReboot" Padding="8" Margin="10,5" Click="ConfirmReboot_Click" AutomationProperties.LabeledBy="{Binding ElementName=RebootButtonText}">
-                                                    <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
-                                                        <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" Glyph="&#xE777;"/>
-                                                        <TextBlock x:Name="RebootButtonText" x:Uid="RebootButtonText" Padding="5,0" TextWrapping="Wrap"/>
-                                                    </StackPanel>
-                                                </Button>
-                                                <Button x:Name="ConfirmShutdown" Padding="8" Margin="10,5" Click="ConfirmShutdown_Click" AutomationProperties.LabeledBy="{Binding ElementName=ShutdownButtonText}">
-                                                    <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
-                                                        <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" Glyph="&#xE7E8;"/>
-                                                        <TextBlock x:Name="ShutdownButtonText" x:Uid="ShutdownButtonText" Padding="5,0" TextWrapping="Wrap"/>
-                                                    </StackPanel>
-                                                </Button>
+                                        </Flyout>
+                                    </Button.Flyout>
+                                </Button>
+                                <Button x:Name="ExitButton" AutomationProperties.LabeledBy="{Binding ElementName=ExitText}" Padding="5" Margin="5,0,0,0">
+                                    <StackPanel Orientation="Horizontal">
+                                        <TextBlock FontFamily="Segoe MDL2 Assets" Text="&#xE711;" FontSize="30" VerticalAlignment="Center" />
+                                    </StackPanel>
+                                    <Button.Flyout>
+                                        <Flyout x:Name="ExitFlyout" Closed="ExitFlyout_Closed">
+                                            <StackPanel>
+                                                <TextBlock x:Name="ExitText" x:Uid="ExitText" TextWrapping="Wrap" Style="{ThemeResource FlyoutPickerTitleTextBlockStyle}" HorizontalAlignment="Center" Margin="5"/>
+                                                <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
+                                                    <Button x:Name="ConfirmExit" Padding="8" Margin="10,5" Click="ConfirmExit_Click" AutomationProperties.LabeledBy="{Binding ElementName=ExitButtonText}">
+                                                        <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
+                                                            <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" Glyph="&#xE711;"/>
+                                                            <TextBlock x:Name="ExitButtonText" x:Uid="Exit" Padding="5,0" TextWrapping="Wrap"/>
+                                                        </StackPanel>
+                                                    </Button>
+                                                    <Button x:Name="ConfirmReboot" Padding="8" Margin="10,5" Click="ConfirmReboot_Click" AutomationProperties.LabeledBy="{Binding ElementName=RebootButtonText}">
+                                                        <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
+                                                            <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" Glyph="&#xE777;"/>
+                                                            <TextBlock x:Name="RebootButtonText" x:Uid="RebootButtonText" Padding="5,0" TextWrapping="Wrap"/>
+                                                        </StackPanel>
+                                                    </Button>
+                                                    <Button x:Name="ConfirmShutdown" Padding="8" Margin="10,5" Click="ConfirmShutdown_Click" AutomationProperties.LabeledBy="{Binding ElementName=ShutdownButtonText}">
+                                                        <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
+                                                            <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" Glyph="&#xE7E8;"/>
+                                                            <TextBlock x:Name="ShutdownButtonText" x:Uid="ShutdownButtonText" Padding="5,0" TextWrapping="Wrap"/>
+                                                        </StackPanel>
+                                                    </Button>
+                                                </StackPanel>
+                                                <ProgressBar x:Name="ShutdownProgessBar" IsIndeterminate="True" Visibility="Collapsed" Margin="10"/>
                                             </StackPanel>
-                                            <ProgressBar x:Name="ShutdownProgessBar" IsIndeterminate="True" Visibility="Collapsed" Margin="10"/>
-                                        </StackPanel>
-                                    </Flyout>
-                                </Button.Flyout>
-                            </Button>
+                                        </Flyout>
+                                    </Button.Flyout>
+                                </Button>
+                            </StackPanel>
                         </StackPanel>
+
                     </StackPanel>
-                    
-                </Frame>
-            </Grid>
+                </StackPanel>
+            
 
             <TextBlock x:Name="BootTaskWarning" x:Uid="BootTaskWarning" Grid.Row="1" VerticalAlignment="Center" HorizontalAlignment="Center" FontWeight="Bold" FontStyle="Italic" Style="{StaticResource SubtitleTextBlockStyle}" Visibility="Collapsed" Margin="5"/>
             <muxc:NavigationView 
                 x:Name="NavView" 
                 Grid.Row="3" 
-                PaneDisplayMode="Top" 
+                PaneDisplayMode="Top"
                 IsBackButtonVisible="Collapsed" 
                 IsSettingsVisible="False" 
                 ItemInvoked="NavView_ItemInvoked"
+                
                 >
                 <muxc:NavigationView.MenuItems>
                     <muxc:NavigationViewItem Tag="run" TabIndex="0" x:Uid="Run" Icon="Play"/>
@@ -147,7 +182,7 @@
                 <muxc:NavigationView.FooterMenuItems>
 
                 </muxc:NavigationView.FooterMenuItems>
-                <Frame x:Name="ContentFrame" IsTabStop="True" Padding="12" />
+                <Frame x:Name="ContentFrame" IsTabStop="True" Padding="12"/>
             </muxc:NavigationView>
         </Grid>
     </Grid>

--- a/src/App/MainPage.xaml
+++ b/src/App/MainPage.xaml
@@ -42,7 +42,7 @@
                         <Setter Target="ContentFrame.Padding" Value="1"></Setter>
                         <Setter Target="HeaderPanel.Orientation" Value="Vertical"></Setter>
                         <Setter Target="ButtonPanel.HorizontalAlignment" Value="Left"></Setter>
-                        <Setter Target="Flipper.Orientation" Value="Vertical"></Setter>
+                        <Setter Target="IndicatorPanel.Orientation" Value="Vertical"></Setter>
                         <Setter Target="NavView.PaneDisplayMode" Value="LeftMinimal"></Setter>
 
                     </VisualState.Setters>
@@ -71,7 +71,7 @@
             <StackPanel x:Name="HeaderPanel" Orientation="Horizontal">
                 <TextBlock x:Name="Header" x:Uid="FactoryOrchestrator" Grid.Column="0" Text="" TextWrapping="Wrap" VerticalAlignment="Center" HorizontalAlignment="Left" FontWeight="Bold" Style="{StaticResource TitleTextBlockStyle}"/>
                 <StackPanel x:Name = "MainControlPanel" Orientation="Horizontal" HorizontalAlignment="Center" Padding="40,0,0,0" Grid.Column="1" Grid.Row="0">
-                        <StackPanel x:Name="Flipper" Orientation="Horizontal">
+                        <StackPanel x:Name="IndicatorPanel" Orientation="Horizontal">
                             <StackPanel Orientation="Vertical" VerticalAlignment="Center" HorizontalAlignment="Left" Margin="5">
                                 <TextBlock x:Name="NetworkName" Text="" Style="{StaticResource CaptionTextBlockStyle}" VerticalAlignment="Center" TextWrapping="Wrap" IsTextSelectionEnabled="True"/>
                                 <TextBlock x:Name="NetworkIp" Text="" Style="{StaticResource CaptionTextBlockStyle}" VerticalAlignment="Center" TextWrapping="Wrap" IsTextSelectionEnabled="True"/>


### PR DESCRIPTION
### **Make FactoryOrchestrator** more _responsive_

PR does three main things:

1. Sets up FactoryOrchestrator to be more responsive by creating app breakpoints in the App.xaml (based on the width of the screen in effective pixels (https://docs.microsoft.com/en-us/windows/apps/design/basics/design-and-ui-intro#effective-pixels-and-scaling))
2. Makes the EditPage.xaml responsive by defining a narrow layout (**Note**: this responsivity prevents elements from disappearing to the right)
### Screenshots
**Smaller window width**
![image](https://user-images.githubusercontent.com/30281766/126055919-ccb5dcc0-225c-46ff-bae3-fc362c461073.png)
**Larger window width**
![image](https://user-images.githubusercontent.com/30281766/126055976-a79f1207-1381-4c45-af26-f328e4553d8a.png)
3. Makes the main page content responsive by laying out the header elements differently to accommodate smaller screen size
### Screenshots
**Large window width**
![image](https://user-images.githubusercontent.com/30281766/126056001-df67f508-cf97-417a-985a-1a1a9f77853f.png)

**Medium window width**
![image](https://user-images.githubusercontent.com/30281766/126056215-a61124c1-365b-4c95-92bd-033592573a4f.png)

**Small window width**
![image](https://user-images.githubusercontent.com/30281766/126056237-26dd9cbe-7d20-4d25-8050-2a70862ca0eb.png)

