### PR TITLE
Made console scrollable by keyboard and adjusted the layout

### DIFF
--- a/src/App/ConsolePage.xaml
+++ b/src/App/ConsolePage.xaml
@@ -37,14 +37,13 @@
             <TextBlock x:Name="ContainerGuiWarningExample" x:Uid="ContainerGuiWarningExample" VerticalAlignment="Center" HorizontalAlignment="Center" FontWeight="Bold"  Visibility="Collapsed" TextWrapping="WrapWholeWords"/>
         </StackPanel>
         <TextBlock x:Name="OutputConst" Grid.Row="4" FontWeight="Bold" VerticalAlignment="Bottom" Padding="5,5,0,5" HorizontalAlignment="Left" x:Uid="OutputConst"/>
-        <StackPanel Orientation="Horizontal" Grid.Row="4" HorizontalAlignment="Right">
+        <ScrollViewer x:Name="ScrollView" HorizontalAlignment="Stretch" HorizontalScrollBarVisibility="Auto" IsTabStop="True" Grid.Row="6" >
+            <TextBox  x:Name="OutputStack" AutomationProperties.LabeledBy="{Binding ElementName=OutputConst}" IsTabStop="False" TextWrapping="NoWrap" IsReadOnly="True" AcceptsReturn="True" ScrollViewer.VerticalScrollBarVisibility="Auto"/>
+        </ScrollViewer>
+        <StackPanel Orientation="Horizontal" Grid.Row="7" HorizontalAlignment="Right" Padding="0,5,0,0">
             <Button x:Name="LaunchRD" x:Uid="LaunchRD" Click="LaunchRD_Click" HorizontalAlignment="Left" Visibility="Collapsed" />
             <Button x:Name="ClearButton" x:Uid="ClearButton" Click="ClearButton_Click" HorizontalAlignment="Left" Margin="5,0,0,0"/>
         </StackPanel>
-        <ScrollViewer x:Name="ScrollView" HorizontalAlignment="Stretch" HorizontalScrollBarVisibility="Auto" Grid.Row="6" IsTabStop="True">
-            <TextBox  x:Name="OutputStack" AutomationProperties.LabeledBy="{Binding ElementName=OutputConst}" TextWrapping="NoWrap" IsReadOnly="True" AcceptsReturn="True" ScrollViewer.VerticalScrollBarVisibility="Auto"/>
-        </ScrollViewer>
-        
     </Grid>
     
 </Page>

--- a/src/App/ConsolePage.xaml
+++ b/src/App/ConsolePage.xaml
@@ -37,12 +37,14 @@
             <TextBlock x:Name="ContainerGuiWarningExample" x:Uid="ContainerGuiWarningExample" VerticalAlignment="Center" HorizontalAlignment="Center" FontWeight="Bold"  Visibility="Collapsed" TextWrapping="WrapWholeWords"/>
         </StackPanel>
         <TextBlock x:Name="OutputConst" Grid.Row="4" FontWeight="Bold" VerticalAlignment="Bottom" Padding="5,5,0,5" HorizontalAlignment="Left" x:Uid="OutputConst"/>
-
-        <ScrollViewer x:Name="ScrollView" HorizontalAlignment="Stretch" HorizontalScrollBarVisibility="Auto" Grid.Row="6">
+        <StackPanel Orientation="Horizontal" Grid.Row="4" HorizontalAlignment="Right">
+            <Button x:Name="LaunchRD" x:Uid="LaunchRD" Click="LaunchRD_Click" HorizontalAlignment="Left" Visibility="Collapsed" />
+            <Button x:Name="ClearButton" x:Uid="ClearButton" Click="ClearButton_Click" HorizontalAlignment="Left" Margin="5,0,0,0"/>
+        </StackPanel>
+        <ScrollViewer x:Name="ScrollView" HorizontalAlignment="Stretch" HorizontalScrollBarVisibility="Auto" Grid.Row="6" IsTabStop="True">
             <TextBox  x:Name="OutputStack" AutomationProperties.LabeledBy="{Binding ElementName=OutputConst}" TextWrapping="NoWrap" IsReadOnly="True" AcceptsReturn="True" ScrollViewer.VerticalScrollBarVisibility="Auto"/>
         </ScrollViewer>
-        <Button x:Name="LaunchRD" x:Uid="LaunchRD" Click="LaunchRD_Click" Grid.Row="7" HorizontalAlignment="Center" Visibility="Collapsed" />
-        <Button x:Name="ClearButton" x:Uid="ClearButton" Click="ClearButton_Click" Grid.Row="7" HorizontalAlignment="Center"/>
+        
     </Grid>
     
 </Page>


### PR DESCRIPTION
**Made console output window focusable by tab**
**Changed the layout of console page to have the buttons in the bottom right instead of the bottom center.** 
![image](https://user-images.githubusercontent.com/30281766/126367687-3f5477b9-ce4c-4f52-b3e4-eb289262eb67.png)
As it were, the buttons overlapped when both were visible
![image](https://user-images.githubusercontent.com/30281766/126363571-5dcbdf2b-0671-4306-a0a4-3420d64f777c.png)
In the figure, the buttons for clearing the console and showing the container UI are on top of each other. 